### PR TITLE
Add a toggle of log and tracing

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -391,3 +391,22 @@ export const Search = styled.input`
     box-shadow: 0 0 0 2px var(--primary);
   }
 `;
+
+
+const playSymbol = String.fromCharCode(parseInt("25B6",16))
+const
+  pauseSymbol = String.fromCharCode(parseInt("25A0",16))
+
+export function RunButton(config: Spec) {
+  NodeButton({
+    text:`${playSymbol} Run`,
+    ...config
+  })
+}
+
+export function PauseButton(config: Spec) {
+  NodeButton({
+    text:`${pauseSymbol} Pause`,
+    ...config
+  })
+}

--- a/src/tabs/log/index.ts
+++ b/src/tabs/log/index.ts
@@ -1,0 +1,2 @@
+export { createLogRecordFx}  from "./model";
+export { Logs } from './view';

--- a/src/tabs/log/model.ts
+++ b/src/tabs/log/model.ts
@@ -1,0 +1,44 @@
+import {createEvent, createStore, guard, createEffect} from "effector";
+import { persist } from 'effector-storage/session'
+
+import {LogMeta} from "../../types.h";
+
+
+const log = createEvent<LogMeta>();
+export const isLogEnabledToggle = createEvent();
+export const logCleared = createEvent();
+
+export const $logs = createStore<LogMeta[]>([], {serialize: 'ignore'});
+export const $isLogEnabled = createStore(false);
+
+type CreateRecord = Pick<LogMeta, 'name' | 'kind' | 'payload'>;
+
+let id = 1e3;
+const nextId = () => (++id).toString(36);
+
+export const createLogRecordFx = createEffect<CreateRecord, LogMeta>({
+  handler({ name, kind, payload }) {
+    return {
+      id: nextId(),
+      kind,
+      name,
+      payload,
+      datetime: new Date(),
+    };
+  },
+});
+
+$isLogEnabled.on(isLogEnabledToggle, value => !value)
+$logs
+  .on(log, (logs, record) => [record, ...logs])
+  .reset(logCleared);
+
+guard({
+  clock: createLogRecordFx.doneData,
+  filter: $isLogEnabled,
+  target: log
+})
+
+persist({
+  store: $isLogEnabled,
+})

--- a/src/tabs/log/view.ts
+++ b/src/tabs/log/view.ts
@@ -1,7 +1,7 @@
-import { Store, createStore, createEvent, combine, restore, Event } from 'effector';
+import { Store, createStore, createEvent, combine, restore } from 'effector';
 import { list, h } from 'forest';
 
-import { LogMeta, Kind, Options } from './types.h';
+import { Kind, Options } from '../../types.h';
 import {
   NodeList,
   Node,
@@ -10,20 +10,26 @@ import {
   Panel,
   Checkbox,
   Input,
-  NodeButton,
-} from './components';
-import { ObjectView } from './object-view';
-import { createJsonSetting, createSetting } from './setting';
-import { trimDomain } from './trim-domain';
+  NodeButton, RunButton, PauseButton,
+} from '../../components';
+import { ObjectView } from '../../object-view';
+import { createJsonSetting, createSetting } from '../../setting';
+import { trimDomain } from '../../trim-domain';
 
 const defaultKinds: Kind[] = ['event', 'store'];
 const kindSetting = createJsonSetting<Kind[]>('filter-kinds', defaultKinds);
 const textSetting = createSetting('filter-text', '');
 
-export function Logs($logs: Store<LogMeta[]>, hotKeyClear: Event<void>, options: Options) {
+import {
+  $logs,
+  $isLogEnabled,
+  isLogEnabledToggle,
+  logCleared,
+} from './model'
+
+export function Logs(options: Options) {
   const toggleKind = createEvent<Kind>();
   const filterChanged = createEvent<string>();
-  const clearClicked = createEvent<MouseEvent>();
 
   const $kinds = createStore(kindSetting.read());
   const $filterText = restore(filterChanged, textSetting.read());
@@ -34,7 +40,7 @@ export function Logs($logs: Store<LogMeta[]>, hotKeyClear: Event<void>, options:
     )
     .watch(kindSetting.write);
   $filterText.watch(textSetting.write);
-  $logs.on(clearClicked, () => []).on(hotKeyClear, () => []);
+
 
   Panel(() => {
     h('span', { text: 'Show: ' });
@@ -64,9 +70,18 @@ export function Logs($logs: Store<LogMeta[]>, hotKeyClear: Event<void>, options:
 
     NodeButton({
       text: 'Clear',
-      handler: { click: clearClicked },
+      handler: { click: logCleared },
       attr: { title: 'Press CTRL+L to clear logs' },
     });
+
+    RunButton({
+      visible: $isLogEnabled.map(value => !value),
+      handler: { click: isLogEnabledToggle }
+    })
+    PauseButton({
+      visible: $isLogEnabled,
+      handler: { click: isLogEnabledToggle },
+    })
   });
 
   NodeList(() => {

--- a/src/tabs/trace/index.ts
+++ b/src/tabs/trace/index.ts
@@ -1,0 +1,7 @@
+export {
+  traceEffectRun,
+  traceEventTrigger,
+  traceStoreChange
+} from "./model";
+
+export {Traces} from './view'

--- a/src/tabs/trace/model.ts
+++ b/src/tabs/trace/model.ts
@@ -1,0 +1,54 @@
+import {createEvent, createStore, guard, merge, sample} from "effector";
+import { persist } from 'effector-storage/session'
+import {
+  StackTrace,
+  TraceEffectRun,
+  TraceEventTrigger,
+  TraceStoreChange
+} from "../../types.h";
+
+export const traceStoreChange = createEvent<TraceStoreChange>();
+export const traceEventTrigger = createEvent<TraceEventTrigger>();
+export const traceEffectRun = createEvent<TraceEffectRun>();
+const traceAdd = createEvent<TraceStoreChange | TraceEventTrigger | TraceEffectRun>();
+const traceFinished = createEvent();
+export const traceCleared = createEvent();
+
+export const $traces = createStore<StackTrace[]>([]);
+const $currentTrace = createStore<StackTrace>({ time: 0, traces: [] });
+export const $isTraceEnabled = createStore(false);
+export const traceEnableToggled = createEvent<void>();
+
+$isTraceEnabled.on(traceEnableToggled, value => !value)
+$traces.on([traceCleared], () => []);
+
+$currentTrace.on(traceAdd, ({ time, traces }, trace) => ({
+  time: time ? time : Date.now(),
+  traces: [...traces, trace],
+}));
+
+
+guard({
+  clock:  merge([traceStoreChange, traceEventTrigger, traceEffectRun]),
+  filter: $isTraceEnabled,
+  target: traceAdd
+})
+
+guard({
+  source: $currentTrace,
+  clock: traceAdd,
+  filter: ({ traces }) => traces.length === 1,
+}).watch(() => queueMicrotask(traceFinished));
+
+const moveTrace = sample({
+  clock: traceFinished,
+  source: $currentTrace,
+});
+
+$traces.on(moveTrace, (stackTraces, newTrace) => [...stackTraces, newTrace]);
+$currentTrace.reset(moveTrace);
+
+
+persist({
+  store: $isTraceEnabled,
+})

--- a/src/tabs/trace/view.ts
+++ b/src/tabs/trace/view.ts
@@ -1,0 +1,140 @@
+import { h, list, remap, text, variant } from 'forest';
+
+import { styled } from 'foliage';
+import {
+  Node,
+  NodeButton,
+  NodeContent,
+  NodeList,
+  Panel,
+  PauseButton,
+  RunButton
+} from '../../components';
+import { ObjectView } from '../../object-view';
+import {
+  $isTraceEnabled,
+  $traces,
+  traceCleared,
+  traceEnableToggled
+} from "./model";
+
+export function Traces() {
+
+  Panel(() => {
+    NodeButton({
+      text: 'Clear',
+      handler: { click: traceCleared },
+      attr: { title: 'Press CTRL+L to clear logs' },
+    });
+
+
+    RunButton({
+      visible: $isTraceEnabled.map(value => !value),
+      handler: { click: traceEnableToggled }
+    })
+    PauseButton({
+      visible: $isTraceEnabled,
+      handler: { click: traceEnableToggled },
+    })
+  });
+
+  NodeList(() => {
+    list({
+      source: $traces,
+      key: 'time',
+      fn({ store: trace }) {
+        TraceTitle(() => {
+          ObjectView({ value: remap(trace, 'time').map((time) => new Date(time)) });
+        });
+        TraceList(() => {
+          list(remap(trace, 'traces'), ({ store: line }) => {
+            variant({
+              source: line,
+              key: 'type',
+              cases: {
+                event({ store }) {
+                  Node({
+                    fn() {
+                      TraceLine(() => {
+                        text`Event "`;
+                        h('span', {
+                          attr: { class: 'event' },
+                          text: remap(store, 'name'),
+                        });
+                        text`" triggered with `;
+                      });
+                      NodeContent(() => ObjectView({ value: remap(store, 'argument') }));
+                    },
+                  });
+                },
+                store({ store }) {
+                  Node({
+                    fn() {
+                      TraceLine(() => {
+                        text`Store "`;
+                        h('span', {
+                          attr: { class: 'store' },
+                          text: remap(store, 'name'),
+                        });
+                        text`" changed from `;
+                      });
+                      NodeContent(() => ObjectView({ value: remap(store, 'before') }));
+                      TraceLine(() => text` to `);
+                      NodeContent(() => ObjectView({ value: remap(store, 'current') }));
+                    },
+                  });
+                },
+                effect({ store }) {
+                  Node({
+                    fn() {
+                      TraceLine(() => {
+                        text`Effect "`;
+                        h('span', {
+                          attr: { class: 'effect' },
+                          text: remap(store, 'name'),
+                        });
+                        text`" triggered with `;
+                      });
+                      NodeContent(() => ObjectView({ value: remap(store, 'argument') }));
+                    },
+                  });
+                },
+              },
+            });
+          });
+        });
+      },
+    });
+  });
+}
+
+const TraceList = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0.25rem 0.5rem;
+`;
+
+const TraceTitle = styled.div`
+  font-size: 0.8rem;
+  margin-top: 1rem;
+  margin-left: 0.5rem;
+`;
+
+const TraceLine = styled.div`
+  display: flex;
+  font-family: 'JetBrains Mono', hasklig, monofur, monospace;
+  margin: 0 0.5rem;
+  flex-shrink: 0;
+
+  .event {
+    color: var(--code-var);
+  }
+
+  .store {
+    color: var(--code-string);
+  }
+
+  .effect {
+    color: var(--code-number);
+  }
+`;

--- a/src/view.ts
+++ b/src/view.ts
@@ -18,7 +18,7 @@ import { Effects } from './effects';
 import { DOMElement, node, spec, val } from 'forest';
 import { createJsonSetting } from './setting';
 import { Files } from './files';
-import { Traces } from './traces';
+import { Traces } from './tabs/trace';
 
 const KEY_B = 2;
 const KEY_L = 12;
@@ -82,7 +82,6 @@ export function Root(
   $effects: Store<Record<string, EffectMeta>>,
   $logs: Store<LogMeta[]>,
   $files: Store<FilesMap>,
-  $traces: Store<StackTrace[]>,
   options: Options = {},
 ) {
   if (options.visible) {
@@ -170,7 +169,7 @@ export function Root(
         traces: {
           title: 'Traces',
           fn() {
-            Traces($traces, clearPressed, options);
+            Traces();
           },
         },
         logs: {

--- a/src/view.ts
+++ b/src/view.ts
@@ -4,14 +4,12 @@ import {
   EffectMeta,
   EventMeta,
   FilesMap,
-  LogMeta,
   Options,
-  StackTrace,
   StoreMeta,
 } from './types.h';
 import { Container, DragHandler } from './components';
 import { Tabs } from './tabs';
-import { Logs } from './logs';
+import { Logs } from './tabs/log';
 import { Stores } from './stores';
 import { Events } from './events';
 import { Effects } from './effects';
@@ -80,7 +78,6 @@ export function Root(
   $stores: Store<Record<string, StoreMeta>>,
   $events: Store<Record<string, EventMeta>>,
   $effects: Store<Record<string, EffectMeta>>,
-  $logs: Store<LogMeta[]>,
   $files: Store<FilesMap>,
   options: Options = {},
 ) {
@@ -175,7 +172,7 @@ export function Root(
         logs: {
           title: 'Logs',
           fn() {
-            Logs($logs, clearPressed, options);
+            Logs( options);
           },
         },
       });


### PR DESCRIPTION
Added Run/Pause buttons for Trace and Logs tabs

Tracing and logging are switch off by default 
It does not resolve the memory leak problem but helps to avoid it (https://github.com/effector/inspector/issues/40)

<img width="794" alt="image" src="https://user-images.githubusercontent.com/10822601/190668302-1177fae1-4271-410a-9d1f-245930d7b9ca.png">