### PR TITLE
change event to keydown for handling inspector visibility

### DIFF
--- a/src/app/view.tsx
+++ b/src/app/view.tsx
@@ -64,7 +64,7 @@ const clearPressed = createEvent();
 const showInspector = createEvent();
 
 if (typeof document === 'object') {
-  document.addEventListener('keypress', (event) => {
+  document.addEventListener('keydown', (event) => {
     if (event.ctrlKey) {
       if (event.key === 'l' || event.keyCode === KEY_L) {
         clearPressed();


### PR DESCRIPTION
fix https://github.com/effector/inspector/issues/30

Due to on https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event keypress event is deprecated  


